### PR TITLE
Feature: aspect ratio control

### DIFF
--- a/contents/config/main.xml
+++ b/contents/config/main.xml
@@ -18,6 +18,30 @@
       <label>Sizing, cropping and positioning of the wallpaper image</label>
       <default>0</default>
     </entry>
+    <entry name="RatioAny" type="bool">
+      <label>Use any picture aspect ratio</label>
+      <default>true</default>
+    </entry>
+    <entry name="Ratio169" type="bool">
+      <label>Use 16x9 picture aspect ratio</label>
+      <default>false</default>
+    </entry>
+    <entry name="Ratio1610" type="bool">
+      <label>Use 16x10 picture aspect ratio</label>
+      <default>false</default>
+    </entry>
+    <entry name="Ratio32" type="bool">
+      <label>Use 3x2 picture aspect ratio</label>
+      <default>false</default>
+    </entry>
+    <entry name="RatioCustom" type="bool">
+      <label>Use custom picture aspect ratio</label>
+      <default>true</default>
+    </entry>
+    <entry name="RatioCustomValue" type="string">
+      <label>Custom picture aspect ratio value</label>
+      <default>3x2,4x3</default>
+    </entry>
     <entry name="APIKey" type="String">
       <label>Personal API key (required for user collections)</label>
     </entry>

--- a/contents/ui/config.qml
+++ b/contents/ui/config.qml
@@ -40,6 +40,12 @@ ColumnLayout {
     property bool cfg_CategoryAnime
     property bool cfg_CategoryPeople
 
+    property bool cfg_RatioAny
+    property bool cfg_Ratio169
+    property bool cfg_Ratio1610
+    property bool cfg_RatioCustom
+    property string cfg_RatioCustomValue
+
     property bool cfg_PuritySFW
     property bool cfg_PuritySketchy
     property bool cfg_PurityNSFW
@@ -133,6 +139,55 @@ ColumnLayout {
             KQuickControls.ColorButton {
                 id: colorButton
                 dialogTitle: i18nd("plasma_wallpaper_org.kde.image", "Select Background Color")
+            }
+        }
+
+        GroupBox {
+            id: aspectRatioInput
+            Kirigami.FormData.label: i18n("Aspect ratio:")
+            RowLayout {
+                anchors.fill: parent
+                CheckBox {
+                    text: i18n("Any")
+                    checked: cfg_RatioAny
+                    onToggled: {
+                        cfg_RatioAny = checked;
+                    }
+                }
+                CheckBox {
+                    text: "16x9"
+                    checked: cfg_Ratio169
+                    enabled: !cfg_RatioAny
+                    onToggled: {
+                        cfg_Ratio169 = checked;
+                    }
+                }
+                CheckBox {
+                    text: "16x10"
+                    checked: cfg_Ratio1610
+                    enabled: !cfg_RatioAny
+                    onToggled: {
+                        cfg_Ratio1610 = checked;
+                    }
+                }
+                CheckBox {
+                    text: i18n("Custom")
+                    checked: cfg_RatioCustom
+                    enabled: !cfg_RatioAny
+                    onToggled: {
+                        cfg_RatioCustom = checked;
+                    }
+                }
+                TextField {
+                    id: customRatioInput
+                    text: cfg_RatioCustomValue
+                    visible: cfg_RatioCustom
+                    enabled: !cfg_RatioAny
+                    onTextChanged: {
+                        cfg_RatioCustomValue = text;
+                    }
+                }
+
             }
         }
 

--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -142,7 +142,19 @@ QQC2.StackView {
             //     url += `color=${wallpaper.configuration.SearchColor}&`
             // }
 
-            url += `ratios=${encodeURIComponent(root.aspectRatio)}&`
+            if (!wallpaper.configuration.RatioAny) {
+                var ratios = []
+                if (wallpaper.configuration.Ratio169) {
+                    ratios.push("16x9");
+                }
+                if (wallpaper.configuration.Ratio1610) {
+                    ratios.push("16x10");
+                }
+                if (wallpaper.configuration.RatioCustom) {
+                    ratios.push(wallpaper.configuration.RatioCustomValue);
+                }
+                url += `ratios=${ratios.join(',')}&`
+            }
 
             url += `q=${encodeURIComponent(wallpaper.configuration.Query)}`
             console.error('using url: ' + url);


### PR DESCRIPTION
Hello. I encountered some weird behavior with fractional scaling:
Aspect ratio isn't calculated right if screen scaled to 150%, probably rounding error, so searching wallpapers for my 16:10 2560x1600 screen was broken.  
To fix this I added control boxes instead of calculation with optional extra string for non-default ratios (multiple options supported). It also makes sense to be able chose different aspect ratio and use cropping and/or scaling positioning.